### PR TITLE
Issue #15 - RequestVerbLine no longer requires "HTTP/1.1"

### DIFF
--- a/src/HttpExecutor.Services/RequestVerbLine.cs
+++ b/src/HttpExecutor.Services/RequestVerbLine.cs
@@ -1,20 +1,28 @@
-﻿using System.Text.RegularExpressions;
+﻿using System;
+using System.Text.RegularExpressions;
 using HttpExecutor.Abstractions;
 
 namespace HttpExecutor.Services
 {
     public class RequestVerbLine : IBlockLine
     {
-        // private const string GroupsRegex = "^(GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS|TRACE)[ \\t]+(?:http(?:s?):\\/\\/(.*:?\\d{,5}))?\\/([a-zA-Z0-9\\.\\/\\-\\?\\=\\&_{}\\$%]*)[ \\t]+HTTP\\/1\\.1[ \\t]*$";
         private const string GroupsRegex =
-            "^(?<verb>GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS|TRACE)[ \\t]+((?<scheme>http:\\/\\/|https:\\/\\/)(?<userpass>.*@)?(?<host>[^:\\/]*(:\\d{1,5}?)?)?)?\\/?(?<path>[a-zA-Z0-9\\.\\/\\-\\?\\=\\&_{}\\$%@:]*)[ \t]+HTTP\\/1\\.1[ \t]*$";
+            "^(?<verb>GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS|TRACE)[ \\t]+((?<scheme>http:\\/\\/|https:\\/\\/)(?<userpass>.*@)?(?<host>[^:\\/]*(:\\d{1,5}?)?)?)?\\/?(?<path>[a-zA-Z0-9\\.\\/\\-\\?\\=\\&_{}\\$%@:]*)(?:[ \t]+HTTP\\/(?:1\\.0|1\\.1|2|3)[ \t]*)?$";
+
+        private readonly Match _regexMatch;
 
         public RequestVerbLine(string value, IBlockLine? previous, int lineNumber)
         {
             Raw = value;
             Previous = previous;
             LineNumber = lineNumber;
-        }
+            _regexMatch = new Regex(GroupsRegex).Match(Raw);
+
+            if (!_regexMatch.Success)
+            {
+                throw new Exception($"Could not properly parse 'RequestVerbLine' from line {lineNumber} using expression: {GroupsRegex}");
+            }
+		}
 
         public LineType LineType => LineType.RequestVerb;
 
@@ -26,14 +34,14 @@ namespace HttpExecutor.Services
 
         public bool VerbHasPayload => Raw.StartsWith("P"); // PUT, PATCH, POST all have bodies
 
-        public string Verb => new Regex(GroupsRegex).Match(Raw).Groups["verb"].Value;
+        public string Verb => _regexMatch.Groups["verb"].Value;
 
-        public string Host => new Regex(GroupsRegex).Match(Raw).Groups["host"].Value;
+        public string Host => _regexMatch.Groups["host"].Value;
 
-        public string Scheme => new Regex(GroupsRegex).Match(Raw).Groups["scheme"].Value;
+        public string Scheme => _regexMatch.Groups["scheme"].Value;
 
-        public string Path => new Regex(GroupsRegex).Match(Raw).Groups["path"].Value;
+        public string Path => _regexMatch.Groups["path"].Value;
 
-        public string UserPass => new Regex(GroupsRegex).Match(Raw).Groups["userpass"].Value;
+        public string UserPass => _regexMatch.Groups["userpass"].Value;
     }
 }

--- a/src/HttpExecutor.Services/RequestVerbParser.cs
+++ b/src/HttpExecutor.Services/RequestVerbParser.cs
@@ -6,7 +6,7 @@ namespace HttpExecutor.Services
 {
     public class RequestVerbParser : IRegexParser
     {
-        private const string RegexString = "^(GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS|TRACE)[ \\t]+(http(s?):\\/\\/.*)?\\/?([a-zA-Z0-9\\.\\/\\-\\?\\=\\&_{}\\$%\\@\\:]*)[ \\t]+HTTP\\/1\\.1[ \\t]*$";
+        private const string RegexString = "^(GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS|TRACE)[ \\t]+(http(s?):\\/\\/.*)?\\/?([a-zA-Z0-9\\.\\/\\-\\?\\=\\&_{}\\$%\\@\\:]*)(?:[ \t]+HTTP\\/(?:1\\.0|1\\.1|2|3)[ \t]*)?$";
 
         public bool IsMatch(string value)
         {


### PR DESCRIPTION
- HTTP protocol version in a verb line is now optional as it was never used in sent request
- now checks for HTTP/1.0, HTTP/1.1, HTTP/2, and HTTP/3 just in case