### PR TITLE
Skip SSL validation

### DIFF
--- a/src/HttpExecutor.Abstractions/IAppOptions.cs
+++ b/src/HttpExecutor.Abstractions/IAppOptions.cs
@@ -23,5 +23,7 @@ namespace HttpExecutor.Abstractions
         bool TerminateOnVariableResolutionFailure { get; }
 
         bool TerminateOnFileAccessFailure { get; }
+
+        bool SkipSslValidation { get; }
     }
 }

--- a/src/HttpExecutor.Services/RequestSender.cs
+++ b/src/HttpExecutor.Services/RequestSender.cs
@@ -28,11 +28,11 @@ namespace HttpExecutor.Services
             
             if (_options.Follow300Responses)
             {
-                client = _httpClientFactory.CreateClient("follow-redirect");
+                client = _httpClientFactory.CreateClient(_options.SkipSslValidation ? "follow-redirect-insecure" : "follow-redirect");
             }
             else
             {
-                client = _httpClientFactory.CreateClient("no-follow-redirect");
+                client = _httpClientFactory.CreateClient(_options.SkipSslValidation ? "no-follow-redirect-insecure" : "no-follow-redirect");
             }
 
             HttpRequestMessage httpRequestMessage;

--- a/src/HttpExecutor/AppOptions.cs
+++ b/src/HttpExecutor/AppOptions.cs
@@ -35,5 +35,8 @@ namespace HttpExecutor
 
         [Option('e', "terminate-on-file-error", Required = false, Default = false, HelpText = "Terminate script on suspected file access failure.")]
         public bool TerminateOnFileAccessFailure { get; set; }
+
+        [Option('k', "insecure", Required = false, Default = false, HelpText = "Skip SSL certificate validation")]
+        public bool SkipSslValidation { get; set; }
     }
 }


### PR DESCRIPTION
curl-like "-k" ("--insecure") option to skip SSL certificate validation, useful for expired or self-signed certificates